### PR TITLE
Move LOCAL_DIR default location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ RUN cd /root && \
     pip install htcondor  && \
     rm /root/get-pip.py
 
+RUN mkdir /usr/local/condor
+
 # The BUILD_DATE value seem to bust the docker cache when the timestamp changes, move to
 # the end
 LABEL org.label-schema.build-date=$BUILD_DATE \

--- a/deployment/conf/.templates/condor_config.local.templ
+++ b/deployment/conf/.templates/condor_config.local.templ
@@ -4,6 +4,14 @@ MASTER_NAME = {{ default .Env.MASTER_NAME "kbase" }}
 SCHEDD_NAME = {{ default .Env.SCHEDD_NAME "kbase" }}
 SCHEDD_HOST = {{ default .Env.SCHEDD_HOST "kbase@condor" }}
 
+LOCAL_DIR = {{ default .Env.LOCAL_DIR "/usr/local/condor" }}
+
+RUN     = $(LOCAL_DIR)/run/condor
+LOG     = $(LOCAL_DIR)/log/condor
+LOCK    = $(LOCAL_DIR)/lock/condor
+SPOOL   = $(LOCAL_DIR)/lib/condor/spool
+EXECUTE = $(LOCAL_DIR)/lib/condor/execute
+
 CONDOR_IDS = 0.0
 
 ALLOW_WRITE = {{ default .Env.ALLOW_WRITE "*" }}

--- a/deployment/conf/condor_config
+++ b/deployment/conf/condor_config
@@ -23,7 +23,8 @@ RELEASE_DIR = /usr
 
 ##  Where is the local condor directory for each host?  This is where the local config file(s), logs and
 ##  spool/execute directories are located. this is the default for Linux and Unix systems.
-LOCAL_DIR = /var
+### KBase: this is set in condor_config.local so that we can templatize it
+#LOCAL_DIR = /var
 
 ##  Where is the machine-specific local config file for each host?
 LOCAL_CONFIG_FILE = /etc/condor/condor_config.local
@@ -56,11 +57,12 @@ use SECURITY : HOST_BASED
 #SEC_PASSWORD_FILE = $(LOCAL_DIR)/lib/condor/pool_password
 
 ##  Pathnames
-RUN     = $(LOCAL_DIR)/run/condor
-LOG     = $(LOCAL_DIR)/log/condor
-LOCK    = $(LOCAL_DIR)/lock/condor
-SPOOL   = $(LOCAL_DIR)/lib/condor/spool
-EXECUTE = $(LOCAL_DIR)/lib/condor/execute
+### KBase: these are set in condor_config.local so that we can templatize it
+#RUN     = $(LOCAL_DIR)/run/condor
+#LOG     = $(LOCAL_DIR)/log/condor
+#LOCK    = $(LOCAL_DIR)/lock/condor
+#SPOOL   = $(LOCAL_DIR)/lib/condor/spool
+#EXECUTE = $(LOCAL_DIR)/lib/condor/execute
 BIN     = $(RELEASE_DIR)/bin
 LIB = $(RELEASE_DIR)/lib64/condor
 INCLUDE = $(RELEASE_DIR)/include/condor


### PR DESCRIPTION
Move LOCAL_DIR out of /var so that we can use one Docker volume mount to accomodate all of the Condor LOCAL_DIR directories.