### PR TITLE
Move LOCAL_DIR to local

### DIFF
--- a/deployment/conf/.templates/condor_config.local.templ
+++ b/deployment/conf/.templates/condor_config.local.templ
@@ -4,6 +4,14 @@ MASTER_NAME = {{ default .Env.MASTER_NAME "kbase" }}
 SCHEDD_NAME = {{ default .Env.SCHEDD_NAME "kbase" }}
 SCHEDD_HOST = {{ default .Env.SCHEDD_HOST "kbase@condor" }}
 
+LOCAL_DIR = {{ default .Env.LOCAL_DIR "/usr/local/condor" }}	
+
+RUN     = $(LOCAL_DIR)/run/condor	
+LOG     = $(LOCAL_DIR)/log/condor	
+LOCK    = $(LOCAL_DIR)/lock/condor	
+SPOOL   = $(LOCAL_DIR)/lib/condor/spool	
+EXECUTE = $(LOCAL_DIR)/lib/condor/execute
+
 CONDOR_IDS = 0.0
 
 ALLOW_WRITE = {{ default .Env.ALLOW_WRITE "*" }}

--- a/deployment/conf/condor_config
+++ b/deployment/conf/condor_config
@@ -23,7 +23,7 @@ RELEASE_DIR = /usr
 
 ##  Where is the local condor directory for each host?  This is where the local config file(s), logs and
 ##  spool/execute directories are located. this is the default for Linux and Unix systems.
-LOCAL_DIR = /var
+###LOCAL_DIR = /var
 
 ##  Where is the machine-specific local config file for each host?
 LOCAL_CONFIG_FILE = /etc/condor/condor_config.local
@@ -56,11 +56,11 @@ use SECURITY : HOST_BASED
 #SEC_PASSWORD_FILE = $(LOCAL_DIR)/lib/condor/pool_password
 
 ##  Pathnames
-RUN     = $(LOCAL_DIR)/run/condor
-LOG     = $(LOCAL_DIR)/log/condor
-LOCK    = $(LOCAL_DIR)/lock/condor
-SPOOL   = $(LOCAL_DIR)/lib/condor/spool
-EXECUTE = $(LOCAL_DIR)/lib/condor/execute
+###RUN     = $(LOCAL_DIR)/run/condor
+###LOG     = $(LOCAL_DIR)/log/condor
+###LOCK    = $(LOCAL_DIR)/lock/condor
+###SPOOL   = $(LOCAL_DIR)/lib/condor/spool
+###EXECUTE = $(LOCAL_DIR)/lib/condor/execute
 BIN     = $(RELEASE_DIR)/bin
 LIB = $(RELEASE_DIR)/lib64/condor
 INCLUDE = $(RELEASE_DIR)/include/condor


### PR DESCRIPTION
Move where LOCAL_DIR is configured to condor_config.local so that it can be overridden by template configuration.